### PR TITLE
Requirement 6

### DIFF
--- a/CalculatorCodingChallenge/Extensions/StringExtensions.cs
+++ b/CalculatorCodingChallenge/Extensions/StringExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace CalculatorCodingChallenge.Extensions
+{
+	public static class StringExtensions
+	{
+        public static string Sanitize(this string Source)
+        {
+            return Source.Replace("\\n", "\n");
+        }
+    }
+}
+

--- a/CalculatorCodingChallenge/Extensions/StringExtensions.cs
+++ b/CalculatorCodingChallenge/Extensions/StringExtensions.cs
@@ -2,8 +2,8 @@
 
 namespace CalculatorCodingChallenge.Extensions
 {
-	public static class StringExtensions
-	{
+    public static class StringExtensions
+    {
         public static string Sanitize(this string Source)
         {
             return Source.Replace("\\n", "\n");

--- a/CalculatorCodingChallenge/Models/StringInputParser.cs
+++ b/CalculatorCodingChallenge/Models/StringInputParser.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 using CalculatorCodingChallenge.Exceptions;
@@ -25,9 +24,7 @@ namespace CalculatorCodingChallenge.Models
                 return new int[] { 0 };
             }
 
-            // inputting \n via console received an escape while unit tests
-            // input don't. We must sanitize correctly for user input
-            string sanitizedInputText = text.Replace("\\n", "\n");
+            string sanitizedInputText = text.Sanitize();
 
             Match matchResult = startingDelimiterRegex.Match(sanitizedInputText);
 

--- a/CalculatorCodingChallenge/Models/StringInputParser.cs
+++ b/CalculatorCodingChallenge/Models/StringInputParser.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 using CalculatorCodingChallenge.Exceptions;
 using CalculatorCodingChallenge.Extensions;
@@ -11,7 +13,10 @@ namespace CalculatorCodingChallenge.Models
         {
         }
 
-        private static readonly char[] separators = new Char[] { ',', '\n' };
+        private static readonly string startingDelimiterPattern = @"^(//)(.)(\n)";
+        private static readonly Regex startingDelimiterRegex = new(StringInputParser.startingDelimiterPattern);
+
+        private static HashSet<string> separators = new() { ",", "\n" };
 
         public static int[] ParseInput(string? text)
         {
@@ -20,13 +25,38 @@ namespace CalculatorCodingChallenge.Models
                 return new int[] { 0 };
             }
 
+            // inputting \n via console received an escape while unit tests
+            // input don't. We must sanitize correctly for user input
+            string sanitizedInputText = text.Replace("\\n", "\n");
+
+            Match matchResult = startingDelimiterRegex.Match(sanitizedInputText);
+
+            if (matchResult.Success)
+            {
+                Group middleMatchingGroup = matchResult.Groups[2];
+
+                string delimeter = middleMatchingGroup.Value;
+                separators.Add(delimeter);
+
+                sanitizedInputText = Regex.Replace(
+                    sanitizedInputText,
+                    startingDelimiterPattern,
+                    ""
+                 );
+            }
+
+            return ParseInputNoDelimiter(sanitizedInputText);
+        }
+
+        private static int[] ParseInputNoDelimiter(string text)
+        {
             // TODO: Refactor this block to make one pass looking at each char,
             // parsing previous chars when delimeter found and performing
             // negative check in the same loop pass
             //
             // This will improve performance in the case requirements change
-            int[] numbers = text.Split(separators)
-                            .Select(numText => numText.Trim().TryParseWithLimit())
+            int[] numbers = text.Split(separators.ToArray(), StringSplitOptions.TrimEntries)
+                            .Select(numText => numText.TryParseWithLimit())
                             .ToArray();
 
             int[] negativeNumbers = numbers.Where(n => n < 0).ToArray();

--- a/CalculatorCodingChallengeTests/BaseControllerTests.cs
+++ b/CalculatorCodingChallengeTests/BaseControllerTests.cs
@@ -166,4 +166,15 @@ public class BaseControllerTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void InvalidatesMultiCharacterDelimiterReturns13()
+    {
+        int expected = 13;
+        string input = "//##\n2#5,10,3";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
 }

--- a/CalculatorCodingChallengeTests/BaseControllerTests.cs
+++ b/CalculatorCodingChallengeTests/BaseControllerTests.cs
@@ -122,4 +122,48 @@ public class BaseControllerTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void SupportsCustomOneCharDelimiterReturns7()
+    {
+        int expected = 7;
+        string input = "//#\n2#5";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SupportsCustomOneCharDelimiterReturns102()
+    {
+        int expected = 102;
+        string input = "//,\n2,ff,100";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HandlesMixedDelimitersReturns20()
+    {
+        int expected = 20;
+        string input = "//#\n2#5,10,3";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HandlesInvalidDelimiterReturns13()
+    {
+        int expected = 13;
+        string input = "/#\n2#5,10,3";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
 }


### PR DESCRIPTION
Support 1 custom delimiter of a single character using the format: //{delimiter}\n{numbers}
- examples: //#\n2#5 will return 7; //,\n2,ff,100 will return 102
- all previous formats should also be supported