### PR TITLE
Requirement 7

### DIFF
--- a/CalculatorCodingChallenge/Controllers/BaseController.cs
+++ b/CalculatorCodingChallenge/Controllers/BaseController.cs
@@ -13,7 +13,9 @@ namespace CalculatorCodingChallenge.Controllers
 
         public static int Compute(string? inputText)
         {
-            int[] parsedInputText = StringInputParser.ParseInput(inputText);
+            StringInputParser inputParser = new();
+
+            int[] parsedInputText = inputParser.ParseInput(inputText);
 
             AddCalculator calculator = new();
 

--- a/CalculatorCodingChallenge/Models/RegexHelper.cs
+++ b/CalculatorCodingChallenge/Models/RegexHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace CalculatorCodingChallenge.Models
 {

--- a/CalculatorCodingChallenge/Models/RegexHelper.cs
+++ b/CalculatorCodingChallenge/Models/RegexHelper.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace CalculatorCodingChallenge.Models
+{
+    public readonly struct RegexDelimiterResult
+    {
+        public RegexDelimiterResult(string cleanedText, string? delimiter)
+        {
+            CleanedText = cleanedText;
+            Delimiter = delimiter;
+        }
+
+        public string CleanedText { get; }
+        public string? Delimiter { get; }
+    }
+
+    public static class RegexHelper
+    {
+        private static readonly string startingSimpleDelimiterPattern = @"^//(.)\n";
+        private static readonly string startingBracketedDelimiterPattern = @"^//\[(.+)\]\n";
+
+        public static RegexDelimiterResult MatchesSimpleDelimiterAndCleansIfMatch(string input)
+        {
+            return MatchesRegexAndCleansIfMatch(input, startingSimpleDelimiterPattern);
+        }
+
+        public static RegexDelimiterResult MatchesBracketedDelimiterAndCleansIfMatch(string input)
+        {
+            return MatchesRegexAndCleansIfMatch(input, startingBracketedDelimiterPattern);
+        }
+
+        public static RegexDelimiterResult MatchesRegexAndCleansIfMatch(
+                string input,
+                string pattern
+            )
+        {
+            Regex regex = new(pattern);
+
+            Match matchResult = regex.Match(input);
+            string? returnDelimiter = null;
+
+            if (matchResult.Success)
+            {
+                Group middleMatchingGroup = matchResult.Groups[1];
+                returnDelimiter = middleMatchingGroup.Value;
+
+                input = Regex.Replace(
+                    input,
+                    pattern,
+                    ""
+                );
+            }
+
+            return new RegexDelimiterResult(input, returnDelimiter);
+        }
+    }
+}
+

--- a/CalculatorCodingChallenge/Models/StringInputParser.cs
+++ b/CalculatorCodingChallenge/Models/StringInputParser.cs
@@ -12,9 +12,9 @@ namespace CalculatorCodingChallenge.Models
         {
         }
 
-        private static readonly HashSet<string> baseSeparators = new() { ",", "\n" };
+        private readonly HashSet<string> separators = new() { ",", "\n" };
 
-        public static int[] ParseInput(string? text)
+        public int[] ParseInput(string? text)
         {
             if (text == null)
             {
@@ -26,15 +26,13 @@ namespace CalculatorCodingChallenge.Models
             RegexDelimiterResult matchedSimpleDelimiter =
                 RegexHelper.MatchesSimpleDelimiterAndCleansIfMatch(sanitizedInputText);
 
-            HashSet<string> combinedSeparators = new (baseSeparators);
-
             if (matchedSimpleDelimiter.Delimiter != null)
             {
-                combinedSeparators.Add(matchedSimpleDelimiter.Delimiter);
+                separators.Add(matchedSimpleDelimiter.Delimiter);
 
                 return ParseInputNoDelimiter(
                     matchedSimpleDelimiter.CleanedText,
-                    combinedSeparators.ToArray()
+                    separators.ToArray()
                 );
             }
 
@@ -43,15 +41,15 @@ namespace CalculatorCodingChallenge.Models
 
             if (matchedBracketedDelimiter.Delimiter != null)
             {
-                combinedSeparators.Add(matchedBracketedDelimiter.Delimiter);
+                separators.Add(matchedBracketedDelimiter.Delimiter);
 
                 return ParseInputNoDelimiter(
                     matchedBracketedDelimiter.CleanedText,
-                    combinedSeparators.ToArray()
+                    separators.ToArray()
                 );
             }
 
-            return ParseInputNoDelimiter(sanitizedInputText, combinedSeparators.ToArray());
+            return ParseInputNoDelimiter(sanitizedInputText, separators.ToArray());
         }
 
         private static int[] ParseInputNoDelimiter(string text, string[] separators)

--- a/CalculatorCodingChallenge/Program.cs
+++ b/CalculatorCodingChallenge/Program.cs
@@ -12,6 +12,10 @@ public class Program
             "separated by a comma. Example 1,2");
         Console.WriteLine("Please note, values greater than 1000 " +
             "will be invalidated and turned to 0.");
+        Console.WriteLine("You can provide custom delimiters in the following formats\n" +
+            "-- multiple character delimiter /[{delimiter}]\\n{numbers}\n" +
+            "-- single character delimiter //{delimiter}\\n{numbers}\n" +
+            "-- empty or invalid delimiters will be invalidated");
 
         string? inputText = Console.ReadLine();
 

--- a/CalculatorCodingChallengeTests/BaseControllerTests.cs
+++ b/CalculatorCodingChallengeTests/BaseControllerTests.cs
@@ -168,10 +168,43 @@ public class BaseControllerTests
     }
 
     [Fact]
+    public void InvalidatesEmptyDelimiterReturns13()
+    {
+        int expected = 13;
+        string input = "//\n2#5,10,3";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
     public void InvalidatesMultiCharacterDelimiterReturns13()
     {
         int expected = 13;
         string input = "//##\n2#5,10,3";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HandlesMultiCharacterBracketedDelimiterReturns66()
+    {
+        int expected = 66;
+        string input = "//[***]\n11***22***33";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void InvalidatesEmptyBracketedDelimiterReturns0()
+    {
+        int expected = 0;
+        string input = "//[]\n11***22***33";
 
         int actual = BaseController.Compute(input);
 


### PR DESCRIPTION
Support 1 custom delimiter of any length using the format: //[{delimiter}]\n{numbers}
- example: //[***]\n11***22***33 will return 66
- all previous formats should also be supported