### PR TITLE
Requirement 8

### DIFF
--- a/CalculatorCodingChallenge/Models/RegexHelper.cs
+++ b/CalculatorCodingChallenge/Models/RegexHelper.cs
@@ -36,8 +36,7 @@ namespace CalculatorCodingChallenge.Models
 
         public static RegexDelimiterResult MatchesSimpleDelimiterAndCleansIfMatch(string input)
         {
-            return MatchesRegexAndCleansIfMatch(
-                input, startingSimpleDelimiterPattern);
+            return MatchesRegexAndCleansIfMatch(input, startingSimpleDelimiterPattern);
         }
 
         public static RegexDelimitersResult MatchesBracketedDelimitersAndCleansIfMatch(string input)

--- a/CalculatorCodingChallenge/Models/RegexHelper.cs
+++ b/CalculatorCodingChallenge/Models/RegexHelper.cs
@@ -30,6 +30,7 @@ namespace CalculatorCodingChallenge.Models
     public static class RegexHelper
     {
         private static readonly string startingSimpleDelimiterPattern = @"^//(.)\n";
+
         private static readonly string startingBracketedDelimiterPattern = @"^//(\[.+\])+?\n";
         private static readonly string valueInsideBracketedListDelimiterPattern = @"\[([^\]]+)\]+";
 

--- a/CalculatorCodingChallenge/Models/RegexHelper.cs
+++ b/CalculatorCodingChallenge/Models/RegexHelper.cs
@@ -15,19 +15,61 @@ namespace CalculatorCodingChallenge.Models
         public string? Delimiter { get; }
     }
 
+    public readonly struct RegexDelimitersResult
+    {
+        public RegexDelimitersResult(string cleanedText, string[] delimiters)
+        {
+            CleanedText = cleanedText;
+            Delimiters = delimiters;
+        }
+
+        public string CleanedText { get; }
+        public string[] Delimiters { get; }
+    }
+
     public static class RegexHelper
     {
         private static readonly string startingSimpleDelimiterPattern = @"^//(.)\n";
-        private static readonly string startingBracketedDelimiterPattern = @"^//\[(.+)\]\n";
+        private static readonly string startingBracketedDelimiterPattern = @"^//(\[.+\])+?\n";
+        private static readonly string valueInsideBracketedListDelimiterPattern = @"\[([^\]]+)\]+";
 
         public static RegexDelimiterResult MatchesSimpleDelimiterAndCleansIfMatch(string input)
         {
-            return MatchesRegexAndCleansIfMatch(input, startingSimpleDelimiterPattern);
+            return MatchesRegexAndCleansIfMatch(
+                input, startingSimpleDelimiterPattern);
         }
 
-        public static RegexDelimiterResult MatchesBracketedDelimiterAndCleansIfMatch(string input)
+        public static RegexDelimitersResult MatchesBracketedDelimitersAndCleansIfMatch(string input)
         {
-            return MatchesRegexAndCleansIfMatch(input, startingBracketedDelimiterPattern);
+            RegexDelimiterResult result = MatchesRegexAndCleansIfMatch(
+                input, startingBracketedDelimiterPattern);
+
+            string? delimiter = result.Delimiter;
+
+            // We have our delimiter returned containing all bracket pairs and
+            // must separate multiple delimiters grouped via brackets if applicable
+            if (delimiter == null)
+            {
+                return new RegexDelimitersResult(result.CleanedText, Array.Empty<string>());
+            }
+
+            string pattern = valueInsideBracketedListDelimiterPattern;
+
+            Regex regex = new(pattern);
+            MatchCollection matchResults = regex.Matches(delimiter);
+
+            List<string> returnDelimiters = new();
+
+            foreach (Match matchResult in matchResults.ToList())
+            {
+                if (matchResult.Success)
+                {
+                    Group delimiterMatchingGroup = matchResult.Groups[1];
+                    returnDelimiters.Add(delimiterMatchingGroup.Value);
+                }
+            }
+
+            return new RegexDelimitersResult(result.CleanedText, returnDelimiters.ToArray());
         }
 
         public static RegexDelimiterResult MatchesRegexAndCleansIfMatch(

--- a/CalculatorCodingChallenge/Models/StringInputParser.cs
+++ b/CalculatorCodingChallenge/Models/StringInputParser.cs
@@ -36,15 +36,15 @@ namespace CalculatorCodingChallenge.Models
                 );
             }
 
-            RegexDelimiterResult matchedBracketedDelimiter =
-                RegexHelper.MatchesBracketedDelimiterAndCleansIfMatch(sanitizedInputText);
+            RegexDelimitersResult matchedBracketedDelimiters =
+                RegexHelper.MatchesBracketedDelimitersAndCleansIfMatch(sanitizedInputText);
 
-            if (matchedBracketedDelimiter.Delimiter != null)
+            if (matchedBracketedDelimiters.Delimiters.Length > 0)
             {
-                separators.Add(matchedBracketedDelimiter.Delimiter);
+                separators.UnionWith(matchedBracketedDelimiters.Delimiters.ToHashSet());
 
                 return ParseInputNoDelimiter(
-                    matchedBracketedDelimiter.CleanedText,
+                    matchedBracketedDelimiters.CleanedText,
                     separators.ToArray()
                 );
             }

--- a/CalculatorCodingChallengeTests/BaseControllerTests.cs
+++ b/CalculatorCodingChallengeTests/BaseControllerTests.cs
@@ -221,4 +221,15 @@ public class BaseControllerTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void HandlesMultiCharacterMultiBracketedAndInvalidatesEmptyBracketedDelimiterReturns110()
+    {
+        int expected = 110;
+        string input = "//[*][!!][][r9r]\n11r9r22*hh*33!!44";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
 }

--- a/CalculatorCodingChallengeTests/BaseControllerTests.cs
+++ b/CalculatorCodingChallengeTests/BaseControllerTests.cs
@@ -210,4 +210,15 @@ public class BaseControllerTests
 
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void HandlesMultiCharacterMultiBracketedDelimiterReturns110()
+    {
+        int expected = 110;
+        string input = "//[*][!!][r9r]\n11r9r22*hh*33!!44";
+
+        int actual = BaseController.Compute(input);
+
+        Assert.Equal(expected, actual);
+    }
 }


### PR DESCRIPTION
Support multiple delimiters of any length using the format: //[{delimiter1}][{delimiter2}]...\n{numbers}
- example: //[*][!!][r9r]\n11r9r22*hh*33!!44 will return 110
- all previous formats should also be supported